### PR TITLE
Adjust API to facilitate piping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
 
   iex> expect process, "Password: "
-  nil
+  %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
 
   iex> exp_send process, "admin\r"
-  :ok
+  %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
 
   iex> expect process, 1_000, ~r/>$/
-  nil
+  %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
 
   iex> exp_send process, "sho ip route\r"
-  :ok
+  %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
 
   iex> expect process, 1_000, fn {event, buffer} ->
     cond do
@@ -59,6 +59,6 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   {:ok, ["sho ip route\r\n", "Codes: C - connected, S - static, R - RIP, M - mobile, B - BGP\r\n       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area \r\n       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2\r\n       E1 - OSPF external type 1, E2 - OSPF external type 2\r\n       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2\r\n       ia - IS-IS inter area, * - candidate default, U - per-user static route\r\n       o - ODR, P - periodic downloaded static route\r\n\r\nGateway of last resort is 192.0.2.2 to network 0.0.0.0\r\n\r\n     198.51.100.0/32 is subnetted, 5 subnets\r\nC       198.51.100.1 is directly connected, Loopback0\r\ni L2    198.51.100.3 [115/100000] via 198.51.100.3, FastEthernet0/1.1\r\ni L2    198.51.100.2 [115/100000] via 198.51.100.2, FastEthernet0/0.1\r\ni L2    198.51.100.5 [115/300000] via 198.51.100.3, FastEthernet0/1.1\r\n                     [115/300000] via 198.51.100.2, FastEthernet0/0.1\r\ni L2    198.51.100.4 [115/200000] via 198.51.100.3, FastEthernet0/1.1\r\n     192.0.2.0/31 is subnetted, 1 subnets\r\nC       192.0.2.2 is directly connected, FastEthernet1/0\r\nS*   0.0.0.0/0 [1/0] via 192.0.2.2\r\nR1>"]}
 
   iex> exp_send process, "exit\r"
-  :ok
+  %Porcelain.Process{err: nil, out: {:send, #PID<0.143.0>}, pid: #PID<0.146.0>}
   ```
 

--- a/lib/expect.ex
+++ b/lib/expect.ex
@@ -12,10 +12,18 @@ defmodule Expect do
     :: Porcelain.Process.t
      | %{pid: any}
 
-  @type pattern :: binary | Regex.t
+  @type data    :: binary
+  @type command :: String.t
+  @type pattern
+    :: binary
+     | Regex.t
+
+  @type buffer         :: binary
+  @type exit_status    :: non_neg_integer
+
   @type expect_error
     :: {:error, :etimedout}
-     | {:error, :exit, non_neg_integer, binary}
+     | {:error, :exit, exit_status, buffer}
 
   require Logger
 
@@ -34,18 +42,26 @@ defmodule Expect do
   @doc """
   Calls `Expect.close/1`. Imported with `use Expect`.
   """
+  @spec exp_close(process)
+    :: :ok
   def exp_close(process),
     do: Expect.close process
 
   @doc """
   Calls `Expect.send/2`. Imported with `use Expect`.
   """
+  @spec exp_send(process, data)
+    :: process
+  @spec exp_send(expect_error, data)
+    :: expect_error
   def exp_send(process, data),
-    do: Expect.send process, data
+    do: Expect.send(process, data)
 
   @doc """
   Calls `Expect.spawn/1`. Imported with `use Expect`.
   """
+  @spec exp_spawn(command)
+    :: process
   def exp_spawn(command),
     do: Expect.spawn command
 
@@ -55,33 +71,53 @@ defmodule Expect do
   @doc """
   Close a spawned process.
   """
-  @spec close(process) :: :ok
+  @spec close(process)
+    :: :ok
   def close(process),
     do: driver().close process
 
   @doc """
   Send `data` to a spawned process.
   """
-  @spec send(process, binary) :: :ok
-  def send(process, data),
-    do: driver().send(process, data)
+  @spec send(process, data)
+    :: process
+  @spec send(expect_error, data)
+    :: expect_error
+  def send(%{pid: _} = process, data) do
+    driver().send(process, data)
+
+    process
+  end
+
+  def send({:error,       _} = error, data) do
+    # Facilitate piping between `exp_send` and `expect`
+    #
+    :ok = Logger.info "Will not send #{inspect data}: got #{inspect error}"
+
+    error
+  end
+
+  def send({:error, _, _, _} = error, data) do
+    # Facilitate piping between `exp_send` and `expect`
+    #
+    :ok = Logger.info "Will not send #{inspect data}: got #{inspect error}"
+
+    error
+  end
 
   @doc """
   Spawn a process for `command`.
   """
-  @spec spawn(String.t) :: process
+  @spec spawn(String.t)
+    :: process
   def spawn(command),
     do: driver().spawn command
 
-  defp timed_out?(timer) do
-    ! Process.read_timer(timer)
-  end
-
-  defp get_expect_value(fun, result) do
+  defp get_expect_value(process, fun, result) do
     try do
       case fun.(result) do
         true ->
-          nil
+          process
 
         false ->
           :error
@@ -100,17 +136,32 @@ defmodule Expect do
     end
   end
 
-  defp _expect(true, _timer, fun, _pid, buffer) do
+  defp timed_out?(timer),
+    do: ! Process.read_timer(timer)
+
+  defp _expect(
+    true = _timed_out,
+    _timer,
+    fun,
+    proc = _process,
+    buffer
+  ) do
     with :error <-
-           get_expect_value(fun, {:timeout, buffer}),
+           get_expect_value(proc, fun, {:timeout, buffer}),
 
          :error <-
-           get_expect_value(fun, {:default, buffer}),
+           get_expect_value(proc, fun, {:default, buffer}),
 
     do: {:error, :etimedout}
   end
 
-  defp _expect(false, timer, fun, pid, buffer) do
+  defp _expect(
+    false = _timed_out,
+    timer,
+    fun,
+    %{pid: pid} = proc = _process,
+    buffer
+  ) do
     timeout = Process.read_timer(timer) || 100
 
     receive do
@@ -118,13 +169,13 @@ defmodule Expect do
         next_buffer = buffer <> data
 
         with :error <-
-               get_expect_value(fun, {:data, next_buffer})
+           get_expect_value(proc, fun, {:data, next_buffer})
         do
           _expect(
             timed_out?(timer),
             timer,
             fun,
-            pid,
+            proc,
             next_buffer
           )
         end
@@ -133,12 +184,13 @@ defmodule Expect do
         :ok = Logger.info "Spawned process exited with status '#{status}'."
 
         with :error <-
-               get_expect_value(fun, {:default, buffer}),
+           get_expect_value(proc, fun, {:default, buffer}),
+
         do: {:error, :exit, status, buffer}
 
     after
       timeout ->
-        _expect(true, timer, fun, pid, buffer)
+        _expect(true, timer, fun, proc, buffer)
     end
   end
 
@@ -151,7 +203,7 @@ defmodule Expect do
   When a bare binary or regex pattern is provided, `expect`
   returns one of the following.
 
-    | on match   | `nil`                                           |
+    | on match   | `process`                                       |
     | on timeout | `{:timeout, buffer}` or `{:default, buffer}`    |
     | on exit    | `{:default, buffer}`                            |
 
@@ -162,7 +214,7 @@ defmodule Expect do
   When a function is provided, `expect` keeps a buffer of
   unmatched data which is passed to `fun` when: new data
   arrives; the timeout period expires; the spawned process
-  exits. In each case, the value(s) passed to `fun` take(s)
+  exits. In each case, the value passed to `fun` take(s)
   one of the following forms.
 
     | on match   | `{:data, buffer}`                               |
@@ -172,29 +224,31 @@ defmodule Expect do
   ## Examples
 
       iex> expect spawned_process, "# "
-      nil
+      %Porcelain.Process{}
 
       iex> expect spawned_process, fn {event, buffer} ->
         cond do
           buffer =~ ~r/>$/ ->
             :match
-
           buffer =~ "a string" ->
             buffer
-
           event == :timeout ->
             :it_timed_out
         end
       end
       {:ok, :match}
       
-      iex> expect spawned_process, fn {_, buffer} -> buffer end
+      iex> expect spawned_process, fn {_, buffer} ->
+        buffer
+      end
       {:ok, ["some data\r\n", "some more data\r\n"]}
       
-      iex> expect process_without_data, fn {:data, buffer} -> buffer end
+      iex> expect process_without_data, fn {:data, buffer} ->
+        buffer
+      end
       {:error, :etimedout}
       
-      iex> expect spawned_process, fn buffer ->
+      iex> expect spawned_process, fn {_, buffer} ->
         cond do
           buffer =~ "non-matching pattern" ->
             buffer
@@ -202,40 +256,76 @@ defmodule Expect do
       end
       {:error, :etimedout}
       
-      iex> expect spawned_process, fn {:timeout, _} -> :it_timed_out end
+      iex> expect spawned_process, fn {:timeout, _} ->
+        :it_timed_out
+      end
       {:ok, :it_timed_out}
-
   """
-  @spec expect(process, pos_integer, pattern)
-    ::        nil | expect_error
-  @spec expect(process, pos_integer, function)
-    :: {:ok, any} | expect_error
+  @spec expect(process, timeout, pattern)
+    :: process
+     | expect_error
+  @spec expect(process, timeout, function)
+    :: {:ok, any}
+     | expect_error
   def expect(process, timeout \\ 10_000, pattern_or_fun)
 
-  def expect(%{pid: pid}, timeout, pattern_or_fun) do
-    fun = get_expect_fun pattern_or_fun
+  def expect(%{pid: _} = process, timeout, fun)
+      when is_function(fun)
+  do
     timer = Process.send_after(:nobody, nil, timeout)
 
-    _expect(timed_out?(timer), timer, fun, pid, "")
+    _expect(timed_out?(timer), timer, fun, process, "")
   end
 
-  defp get_expect_fun(pattern_or_fun) do
-    case pattern_or_fun do
-      fun when is_function(fun) ->
-        fun
+  def expect(%{pid: _} = process, timeout, pattern)
+      when is_binary(pattern)
+  do
+    fun = wrap_pattern_in_function pattern
 
-      :any ->
-        wrap_pattern ""
-
-      %Regex{} = pattern ->
-        wrap_pattern pattern
-
-      pattern when is_binary(pattern) ->
-        wrap_pattern pattern
-    end
+    expect(process, timeout, fun)
   end
 
-  defp wrap_pattern(pattern) do
+  def expect(
+    %{pid: _} = process,
+    timeout,
+    %Regex{} = pattern
+  ) do
+    fun = wrap_pattern_in_function pattern
+
+    expect(process, timeout, fun)
+  end
+
+  def expect(%{pid: _} = process, timeout, :any) do
+    fun = wrap_pattern_in_function ""
+
+    expect(process, timeout, fun)
+  end
+
+  def expect(%{pid: _} = _process, _timeout, term) do
+    message = "Unrecognized pattern or function: #{inspect term}"
+
+    :ok = Logger.error message
+
+    raise message
+  end
+
+  def expect({:error,       _} = error, _timeout, term) do
+    # Facilitate piping between `exp_send` and `expect`
+    #
+    :ok = Logger.info "Will not expect #{inspect term}: got #{inspect error}"
+
+    error
+  end
+
+  def expect({:error, _, _, _} = error, _timeout, term) do
+    # Facilitate piping between `exp_send` and `expect`
+    #
+    :ok = Logger.info "Will not expect #{inspect term}: got #{inspect error}"
+
+    error
+  end
+
+  defp wrap_pattern_in_function(pattern) do
     fn {:data, buffer} -> buffer =~ pattern end
   end
 end

--- a/lib/expect/driver.ex
+++ b/lib/expect/driver.ex
@@ -9,14 +9,20 @@ defmodule Expect.Driver do
 
   @type process
     :: Porcelain.Process.t
-     | %{pid: any}
+     | %{pid: pid | nil}
 
   @doc "Close a spawned process."
-  @callback close(process) :: :ok
+  @callback close(process)
+    :: :ok
 
   @doc "Send `data` to a spawned process."
-  @callback send(process, data :: binary) :: :ok
+  @callback send(
+    process :: process,
+    data    :: binary
+  ) :: :ok
 
   @doc "Spawn a process for `command`."
-  @callback spawn(command :: String.t) :: process
+  @callback spawn(
+    command :: String.t
+  ) :: process
 end

--- a/lib/expect/driver/dummy.ex
+++ b/lib/expect/driver/dummy.ex
@@ -7,9 +7,12 @@ defmodule Expect.Driver.Dummy do
 
   @behaviour Expect.Driver
 
-  def close(_),   do: :ok
+  def close(_process),
+    do: :ok
 
-  def send(_, _), do: :ok
+  def send(_process, _data),
+    do: :ok
 
-  def spawn(_),   do: %{pid: nil}
+  def spawn(_command),
+    do: %{pid: nil}
 end

--- a/lib/expect/driver/porcelain.ex
+++ b/lib/expect/driver/porcelain.ex
@@ -11,7 +11,7 @@ defmodule Expect.Driver.Porcelain do
   @type command :: String.t
   @type process
     :: Porcelain.Process.t
-     | %{pid: any}
+     | %{pid: pid | nil}
 
   @spec close(process)
     :: :ok

--- a/test/expect/driver/porcelain_test.exs
+++ b/test/expect/driver/porcelain_test.exs
@@ -4,12 +4,11 @@ defmodule Expect.Driver.PorcelainTest do
   @moduletag :integrated
 
   alias Expect.Driver.Porcelain, as: Driver
-  alias Porcelain.Process, as: ExpProcess
 
   test "it spawns a process, sends data, receives data, and closes the process" do
     process = Driver.spawn "cat"
 
-    assert %ExpProcess{pid: _} = process
+    assert %Porcelain.Process{pid: _} = process
     assert Driver.send(process, "test data") == :ok
 
     assert_receive {_, :data, :out, "test data"}


### PR DESCRIPTION
* `send/2` returns `process` instead of `:ok`
* `expect` accepts an `expect_error` as first argument
* reformat tests and code to 60 columns