### PR TITLE
porcelain2.ex needed to have a module name change

### DIFF
--- a/lib/expect/driver/porcelain2.ex
+++ b/lib/expect/driver/porcelain2.ex
@@ -2,35 +2,33 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-defmodule Expect.Driver.Porcelain do
+defmodule Expect.Driver.Porcelain2 do
   @moduledoc false
+  alias Porcelain2, as: Porcelain
 
   @behaviour Expect.Driver
 
-  @type data    :: binary
-  @type command :: String.t
-  @type process
-    :: Porcelain.Process.t
-     | %{pid: pid | nil}
+  @type data :: binary
+  @type command :: String.t()
+  @type process ::
+          Porcelain.Process.t()
+          | %{pid: pid | nil}
 
-  @spec close(process)
-    :: :ok
+  @spec close(process) :: :ok
   def close(process) do
-    true = Porcelain.Process.stop process
+    true = Porcelain.Process.stop(process)
 
     :ok
   end
 
-  @spec send(process, data)
-    :: :ok
+  @spec send(process, data) :: :ok
   def send(process, data) do
     _ = Porcelain.Process.send_input(process, data)
 
     :ok
   end
 
-  @spec spawn(command)
-    :: process
+  @spec spawn(command) :: process
   def spawn(command) do
     Porcelain.spawn_shell(
       command,

--- a/mix.exs
+++ b/mix.exs
@@ -2,28 +2,29 @@ defmodule Expect.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :expect_ex,
+    [
+      app: :expect_ex,
       version: "0.0.4",
       name: "expect-elixir",
       source_url: "https://gitlab.com/jonnystorm/expect-elixir",
       elixir: "~> 1.3",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: [extras: ["README.md"]],
       dialyzer: [
         add_plt_apps: [
           :logger,
-          :porcelain,
+          :porcelain
         ],
         ignore_warnings: "dialyzer.ignore",
         flags: [
           :unmatched_returns,
           :error_handling,
           :race_conditions,
-          :underspecs,
-        ],
-      ],
+          :underspecs
+        ]
+      ]
     ]
   end
 
@@ -34,20 +35,20 @@ defmodule Expect.Mixfile do
     do: [driver: Expect.Driver.Porcelain]
 
   def application do
-    [ applications: [
+    [
+      applications: [
         :logger,
         :porcelain
       ],
-      env: Keyword.merge([], get_env(Mix.env))
+      env: Keyword.merge([], get_env(Mix.env()))
     ]
   end
 
   defp deps do
-    [ { :porcelain,
-        git: "https://github.com/alco/porcelain",
-        ref: "acfc0f0a6987aadb08f495a578e22ef624342685"
-      },
-      {:ex_doc, "~> 0.13", only: :dev},
+    [
+      {:porcelain,
+       git: "https://github.com/alco/porcelain", ref: "acfc0f0a6987aadb08f495a578e22ef624342685"},
+      {:ex_doc, "~> 0.13", only: :dev}
     ]
   end
 end


### PR DESCRIPTION
when compiling in my project I recieved the following error:

==> expect_ex
Compiling 6 files (.ex)

== Compilation error in file lib/expect/driver/porcelain2.ex ==
** (CompileError) lib/expect/driver/porcelain2.ex:5: cannot define module Expect.Driver.Porcelain because it is currently being defined in lib/expect/driver/porcelain.ex:5
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6

Renamed the porcelain2.ex module and added the alias, same behavior as expect.ex vs expect2.ex.